### PR TITLE
Ensure the optional Java package gets installed after the apt::update

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -39,6 +39,10 @@ class logstash::java {
             $package = 'openjdk-7-jre-headless'
           }
         }
+        if $logstash::manage_repo {
+          include ::apt
+          Class['apt::update'] -> Package<| tag == 'java-package' |>
+        }
       }
       'OpenSuSE': {
         $package = 'java-1_6_0-openjdk'
@@ -58,7 +62,8 @@ class logstash::java {
   ## Install the java package unless already specified somewhere else
   if !defined(Package[$package]) {
     package { $package:
-      ensure => present
+      ensure => present,
+      tag    => ['java-package'],
     }
   }
 }


### PR DESCRIPTION
Hi,
this would be an additional commit to your https://github.com/elastic/puppet-logstash/pull/242 PR.
Without that we get the error while ithe logstash module installs the optional Java package.
